### PR TITLE
feat: allow xpath for test regression against element + Windows support

### DIFF
--- a/pytest_image_diff/splinter.py
+++ b/pytest_image_diff/splinter.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 import pytest
 from tempfile import NamedTemporaryFile
 from typing import Optional, Generator
@@ -19,6 +21,7 @@ if Browser:
             browser: Optional[Browser] = None,
             threshold: Optional[float] = None,
             suffix: Optional[str] = None,
+            xpath: Optional[str] = "",
         ) -> bool:
             pass
 
@@ -36,6 +39,7 @@ if Browser:
         :param browser: optional, by default from `browser` fixture
         :param threshold: float, by default from `image_diff_threshold`
         :param suffix: str, need for multiple checks  by one test
+        :param xpath: str, optional xpath expression to select an element to screenshot instead of page
         """
         default_browser = browser
 
@@ -43,15 +47,38 @@ if Browser:
             browser: Optional[Browser] = None,
             threshold: Optional[float] = None,
             suffix: Optional[str] = "",
+            xpath: Optional[str] = "",
         ) -> bool:
             if browser is None:
                 browser = default_browser
 
             if threshold is None:
                 threshold = image_diff_threshold
-            tf = NamedTemporaryFile(suffix=".png")
-            image = tf.name
-            browser.driver.save_screenshot(image)
-            return image_regression(image, threshold, suffix)
+
+            with NamedTemporaryFile(suffix=".png", delete=False) as tf:
+                temp_image_path = pathlib.Path(tf.name)
+
+            try:
+                screenshot_path = os.fspath(temp_image_path)
+
+                if xpath:
+                    # `unique_file=False` since we already have a temporary file
+                    #
+                    # Since an xpath screenshot composes its own file name, we need to give it the prefix and
+                    # suffix as separate parameters. `:-4` for the path without extension, then suffix given manually.
+                    browser.find_by_xpath(xpath).first.screenshot(screenshot_path[:-4],
+                                                                  suffix=screenshot_path[-4:],
+                                                                  unique_file=False,
+                                                                  full=True,
+                                                                  )
+                else:
+                    browser.driver.save_screenshot(screenshot_path)
+
+                result = image_regression(screenshot_path, threshold, suffix)
+            finally:
+                temp_image_path.unlink(missing_ok=True)
+
+            return result
+
 
         yield _factory


### PR DESCRIPTION
Warning: This patch does two things, which I sadly didn't have time to split out into separate PRs.

1) Allow a user to give an optional `xpath` qualifier when calling `screenshot_regression`. The regression will then be tested against this single element instead of the whole page.
2) Make pytest-image-diff with splinter work properly on Windows (see issue #1). Since Windows requires us to close the temp file first, we make the temp file persistent, close it, and then tells splinter to write to it. Afterwards we clean up the temporary file before returning from the function.