### PR TITLE
fix(hansbug): support windows

### DIFF
--- a/pytest_image_diff/plugin.py
+++ b/pytest_image_diff/plugin.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Optional, NamedTuple, cast, Callable, Generator, Union
 
 import pytest
@@ -62,7 +63,7 @@ def image_diff_dir(image_diff_root: str) -> PathType:
     """
     Path for store diff images. by default - '{image_diff_root}.tests/image_diff/'
     """
-    return os.path.join(image_diff_root, ".tests/image_diff/")
+    return os.path.join(image_diff_root, ".tests", "image_diff")
 
 
 @pytest.fixture(scope="session")
@@ -123,8 +124,8 @@ def _image_diff_info(
 
     def _factory(image: ImageFileType, suffix: Optional[str] = None) -> DiffInfo:
         test_info = get_test_info(request)
-        class_name = test_info.class_name
-        test_name = test_info.test_name
+        class_name = re.sub(r'[^\w_. -]', '_', test_info.class_name)
+        test_name = re.sub(r'[^\w_. -]', '_', test_info.test_name)
         if suffix is None:
             # Todo enumerate every call
             suffix = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,4 @@ def image_diff_dir(image_diff_root: str) -> PathType:
     """
     Path for store diff images. by default - '{image_diff_root}.tests/image_diff/'
     """
-    return pathlib.Path(image_diff_root) / ".tests/image_diff/"
+    return pathlib.Path(image_diff_root) / ".tests" / "image_diff"


### PR DESCRIPTION
Error ocurred when using `0.0.10`: https://github.com/deepghs/imgutils/actions/runs/4374371360/jobs/7653718606

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'D:\\a\\imgutils\\imgutils\\.tests/image_diff/test.data.test_image.TestDataImage\\test_load_image[D:'
mode = 511, exist_ok = False

    def makedirs(name, mode=0o777, exist_ok=False):
        """makedirs(name [, mode=0o777][, exist_ok=False])
    
        Super-mkdir; create a leaf directory and all intermediate ones.  Works like
        mkdir, except that any intermediate path segment (not just the rightmost)
        will be created if it does not exist. If the target directory already
        exists, raise an OSError if exist_ok is False. Otherwise no exception is
        raised.  This is recursive.
    
        """
        head, tail = path.split(name)
        if not tail:
            head, tail = path.split(head)
        if head and tail and not path.exists(head):
            try:
                makedirs(head, exist_ok=exist_ok)
            except FileExistsError:
                # Defeats race condition when another thread created the path
                pass
            cdir = curdir
            if isinstance(tail, bytes):
                cdir = bytes(curdir, 'ASCII')
            if tail == cdir:           # xxx/newdir/. exists if xxx/newdir exists
                return
        try:
>           mkdir(name, mode)
E           OSError: [WinError [123](https://github.com/deepghs/imgutils/actions/runs/4374371360/jobs/7653718606#step:14:124)] The filename, directory name, or volume label syntax is incorrect: 'D:\\a\\imgutils\\imgutils\\.tests/image_diff/test.data.test_image.TestDataImage\\test_load_image[D:'

c:\hostedtoolcache\windows\python\3.7.9\x64\lib\os.py:223: OSError
```


After using this pr, it's okay now. https://github.com/deepghs/imgutils/actions/runs/4374584140/jobs/7654199946